### PR TITLE
Update SUMMARY.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -111,7 +111,7 @@
   * [Discord Webhooks](fr/module/discord/README.md)
   * [Efficience des bâtiments](fr/module/GcG/README.md)
   * [Filtre du marché](fr/module/marche/README.md)
-  * [GcG](fr/module/GcG/README.md)
+  * [GcG](fr/module/gcg/README.md)
   * [Incidents](fr/module/incident/README.md) 
   * [Infos de l'éclaireur](fr/module/eclaireur/README.md)
   * [Infos Système](fr/module/info_technique/README.md)


### PR DESCRIPTION
link für GcG (GvG) ist nicht präsent auf dem website.
Eventuell wägen GrossenBuchstaben in namen der Register.
habe ich diese geändert.